### PR TITLE
Migrate to LawRun kernle manager && Added CPU Check

### DIFF
--- a/LawRun.Kernel
+++ b/LawRun.Kernel
@@ -2,9 +2,9 @@
 ##############################LawRun-LICENSE####################################
 # LawRun-Kernel Edit.      #####################   **      ******   negrroo    #
 # Negrroo                  #                   #   **      *    *   **   **    #
-# SPECTRUM KERNEL MANAGER  #  LawRun Features  #   **      ******   **  **     #
-# Franco's fku profiles    #                   #   **      **       *****      #
-# Morpho KERNEL MANAGER    #####################   ******* ** **    **  **     #
+# LawRun                   #  LawRun Features  #   **      ******   **  **     #
+# Kernel                   #                   #   **      **       *****      #
+# Manager                  #####################   ******* ** **    **  **     #
 # Just Try to be like us   #LawRun------LICENSE#   ******* **   **  **   **    #
 ############################You Can  Contact Us#################################
 

--- a/META-INF/com/google/android/update-binary
+++ b/META-INF/com/google/android/update-binary
@@ -39,6 +39,29 @@ ui_print " ";
 show_progress 1.34 0;
 set_progress 0.8;
 
+do_cpucheck;
+do_cpucheck(){
+  test "$(file_getprop anykernel.sh do.cpucheck)" == 1 || return 1;
+  local board vendorboard platform vendorplatform cpuname match testname;
+  ui_print "Checking cpu...";
+  board=$(file_getprop /system/build.prop ro.product.board);
+  platform=$(file_getprop /system/build.prop ro.board.platform);
+  vendorboard=$(file_getprop /vendor/build.prop ro.product.board);
+  vendorplatform=$(file_getprop /vendor/build.prop ro.board.platform);
+  for testname in $(file_getprop anykernel.sh 'cpu.name.*'); do
+    for cpuname in $board $platform $vendorboard $vendorplatform; do
+      if [ "$cpuname" == "$testname" ]; then
+        ui_print "$testname" " ";
+        match=1;
+        break 2;
+      fi;
+    done;
+  done;
+  if [ ! "$match" ]; then
+    abort "Unsupported CPU. Aborting...";
+  fi;
+}
+
 file_getprop() { grep "^$2" "$1" | cut -d= -f2; }
 cleanup() { rm -rf /tmp/anykernel; }
 if [ "$(file_getprop /tmp/anykernel/anykernel.sh do.cleanuponabort)" == 1 ]; then

--- a/anykernel.sh
+++ b/anykernel.sh
@@ -7,7 +7,9 @@
 # begin properties
 properties() {
 do.cleanup=1
-do.cleanuponabort=0
+do.cleanuponabort=1
+do.cpucheck=1
+cpu.name1=sdm845
 } # end properties
 
 # shell variables

--- a/ramdisk/overlay.d/init.LawRun-Profiles.rc
+++ b/ramdisk/overlay.d/init.LawRun-Profiles.rc
@@ -1,63 +1,37 @@
 # negrroo
 # LawRun-Kernel Edit.
-# SPECTRUM KERNEL MANAGER
-# MORPHO KERNEL MANAGER
+# LawRun Kernel Manager Support
 # Ramdisk file for profile based kernel management
 # Implimentation inspired by Franco's fku profiles
 
 # Initialization
 on property:sys.boot_completed=1
 
-   # Enable Spectrum support
-   setprop spectrum.support 1
-
-   # Add kernel name
-   setprop persist.spectrum.kernel LawRun
+   # Enable LawRun support
+   setprop lawrun.support 1
 
 
 # Balance
-on property:persist.spectrum.profile=0
+on property:persist.lawrun.profile=0
    exec u:r:init:s0 root root -- /sbin/spa balance
    exec u:r:magisk:s0 root root -- /sbin/spa balance
 
-# Performance 
-on property:persist.spectrum.profile=1
-   exec u:r:init:s0 root root -- /sbin/spa performance
-   exec u:r:magisk:s0 root root -- /sbin/spa performance
-
-# Battery
-on property:persist.spectrum.profile=2
-   exec u:r:init:s0 root root -- /sbin/spa battery
-   exec u:r:magisk:s0 root root -- /sbin/spa battery
-
-# Gaming
-on property:persist.spectrum.profile=3
-   exec u:r:init:s0 root root -- /sbin/spa gaming
-   exec u:r:magisk:s0 root root -- /sbin/spa gaming
-
 # Extra Balanced
-on property:persist.spectrum.profile=4
+on property:persist.lawrun.profile=1
    exec u:r:init:s0 root root -- /sbin/spa ebalance
    exec u:r:magisk:s0 root root -- /sbin/spa ebalance
 
-
-
-# Extra Balanced
-on property:persist.morpho.profile=3
-   setprop persist.spectrum.profile 4
-
-# Balance
-on property:persist.morpho.profile=2
-   setprop persist.spectrum.profile 0
-
-# Performance
-on property:persist.morpho.profile=4
-   setprop persist.spectrum.profile 1
-
 # Battery
-on property:persist.morpho.profile=1
-   setprop persist.spectrum.profile 2
+on property:persist.lawrun.profile=2
+   exec u:r:init:s0 root root -- /sbin/spa battery
+   exec u:r:magisk:s0 root root -- /sbin/spa battery
+
+# Performance 
+on property:persist.lawrun.profile=3
+   exec u:r:init:s0 root root -- /sbin/spa performance
+   exec u:r:magisk:s0 root root -- /sbin/spa performance
 
 # Gaming
-on property:persist.morpho.profile=5
-   setprop persist.spectrum.profile 3
+on property:persist.lawrun.profile=4
+   exec u:r:init:s0 root root -- /sbin/spa gaming
+   exec u:r:magisk:s0 root root -- /sbin/spa gaming


### PR DESCRIPTION
The other kernel managers like Morpho,Spectrum has some useless things like set on boot service which is already included in LawRun profile.
And changing profile via init script is more convenient than a service running on background